### PR TITLE
fix broken links in README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ API which has become part of the 2.4.48 release..
 
 ### Installation from source
 
-Run the usual autoconf/automake magic incantations. You need a built Apache trunk and specify the `--with-apxe=<path>/bin/apxs` on configuration if that is not in your `$PATH`. Also, you need [crustls](https://github.com/abtterinternet/crustls/) installed.
+Run the usual autoconf/automake magic incantations. You need a built Apache trunk and specify the `--with-apxe=<path>/bin/apxs` on configuration if that is not in your `$PATH`. Also, you need [crustls](https://github.com/abetterinternet/crustls/) installed.
 
 Run the usual autoconf/automake magic incantations.
 

--- a/README.md.bak
+++ b/README.md.bak
@@ -41,7 +41,7 @@ API which has become part of the 2.4.48 release..
 
 ### Installation from source
 
-Run the usual autoconf/automake magic incantations. You need a built Apache trunk and specify the `--with-apxe=<path>/bin/apxs` on configuration if that is not in your `$PATH`. Also, you need [crustls](https://github.com/abtterinternet/crustls/) installed.
+Run the usual autoconf/automake magic incantations. You need a built Apache trunk and specify the `--with-apxe=<path>/bin/apxs` on configuration if that is not in your `$PATH`. Also, you need [crustls](https://github.com/abetterinternet/crustls/) installed.
 
 Run the usual autoconf/automake magic incantations.
 


### PR DESCRIPTION
I noticed `README.md` and `README.md.bak` had a typo in the link to the
GitHub organization.

I went for a quick fix but we could consider using reference style links
to avoid duplication of the hyperlink.